### PR TITLE
Replaced the reserved word for with the word with in arrayOfColorsWithCo...

### DIFF
--- a/Chameleon/ChameleonMacros.h
+++ b/Chameleon/ChameleonMacros.h
@@ -43,7 +43,7 @@
 
 #pragma mark - Chameleon - NSArray Methods Shorthand
 //NSArray Methods Shorthand
-#define ColorScheme(colorSchemeType,color,isFlatScheme) [NSArray arrayOfColorsWithColorScheme:colorSchemeType for:color flatScheme:isFlatScheme]
+#define ColorScheme(colorSchemeType,color,isFlatScheme) [NSArray arrayOfColorsWithColorScheme:colorSchemeType with:color flatScheme:isFlatScheme]
 
 #pragma mark - Chameleon - Special Colors Shorthand
 //Special Colors Shorthand

--- a/Chameleon/NSArray+Chameleon.h
+++ b/Chameleon/NSArray+Chameleon.h
@@ -61,6 +61,6 @@ typedef NS_ENUM (NSInteger, ColorScheme) {
  *
  *  @return An array of 5 color objects in the HSB colorspace.
  */
-+ (NSArray *)arrayOfColorsWithColorScheme:(ColorScheme)colorScheme for:(UIColor *)color flatScheme:(BOOL)isFlatScheme;
++ (NSArray *)arrayOfColorsWithColorScheme:(ColorScheme)colorScheme with:(UIColor *)color flatScheme:(BOOL)isFlatScheme;
 
 @end

--- a/Chameleon/NSArray+Chameleon.m
+++ b/Chameleon/NSArray+Chameleon.m
@@ -35,7 +35,7 @@
 
 #pragma mark - Chameleon - Public Color Scheme Methods
 
-+ (NSArray *)arrayOfColorsWithColorScheme:(ColorScheme)colorScheme for:(UIColor *)color flatScheme:(BOOL)isFlatScheme {
++ (NSArray *)arrayOfColorsWithColorScheme:(ColorScheme)colorScheme with:(UIColor *)color flatScheme:(BOOL)isFlatScheme {
     
     //Extract HSB values from input color
     CGFloat h, s, b, a;


### PR DESCRIPTION
In response to #10 , I changed the parameter name "for" to the word "with" in the NSArray color scheme method resolving this issue when using the framework in Swift. 
